### PR TITLE
Implementation of Salvage Logging

### DIFF
--- a/src/stand-ranking/TimeSinceDisturbanceRank.cs
+++ b/src/stand-ranking/TimeSinceDisturbanceRank.cs
@@ -1,0 +1,45 @@
+﻿// This file is part of the Harvest Management library for LANDIS-II.
+// For copyright and licensing information, see the NOTICE and LICENSE
+// files in this project's top-level directory, and at:
+//   http://landis-extensions.googlecode.com/svn/libs/harvest-mgmt/trunk/
+
+using Landis.SpatialModeling;
+
+namespace Landis.Library.HarvestManagement
+{
+    /// <summary>
+    /// A stand ranking method based on the time since last fire and wind disturbances
+    /// </summary>
+    public class TimeSinceDisturbanceRank
+        : StandRankingMethod
+    {
+        //---------------------------------------------------------------------
+
+        public TimeSinceDisturbanceRank()
+        {
+        }
+
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// Computes the rank for a stand.
+        /// </summary>
+        protected override double ComputeRank(Stand stand, int i)
+        {
+            SiteVars.GetExternalVars();
+            
+            foreach(IRequirement req in Requirements)
+            {
+                //check for fire or wind requirements
+                if(req is TimeSinceLastFire || req is TimeSinceLastWind)
+                {
+                    if(req.MetBy(stand))
+                    {
+                        return 1;
+                    }
+                }
+            }
+            return 0; //if we are still here, stand does not meet requirements
+        }
+    }
+}

--- a/src/stand-ranking/TimeSinceLastFire.cs
+++ b/src/stand-ranking/TimeSinceLastFire.cs
@@ -1,0 +1,51 @@
+﻿// This file is part of the Harvest Management library for LANDIS-II.
+// For copyright and licensing information, see the NOTICE and LICENSE
+// files in this project's top-level directory, and at:
+//   http://landis-extensions.googlecode.com/svn/libs/harvest-mgmt/trunk/
+
+using Landis.SpatialModeling;
+
+namespace Landis.Library.HarvestManagement
+{
+    /// <summary>
+    /// A ranking requirement which marks a stand for harvest if it has met the time since last fire
+    /// </summary>
+    public class TimeSinceLastFire
+        : IRequirement
+    {
+        private ushort timeSinceFire;
+
+        //---------------------------------------------------------------------
+
+        public TimeSinceLastFire(ushort firetime)
+        {
+            timeSinceFire = firetime;
+        }
+
+        //---------------------------------------------------------------------
+
+        bool IRequirement.MetBy(Stand stand)
+        {
+            double avgtime = 0;
+            int num = 0;
+
+            if(SiteVars.TimeOfLastFire != null)
+            {
+                foreach(ActiveSite site in stand)
+                {
+                    avgtime = avgtime + SiteVars.TimeOfLastFire[(Site)site];
+                    num = num + 1;
+                }
+            }
+
+            avgtime = avgtime / num;
+
+            if(num == 0)
+            {
+                return false;
+            }
+
+            return avgtime >= timeSinceFire;
+        }
+    }
+}

--- a/src/stand-ranking/TimeSinceLastWind.cs
+++ b/src/stand-ranking/TimeSinceLastWind.cs
@@ -1,0 +1,51 @@
+﻿// This file is part of the Harvest Management library for LANDIS-II.
+// For copyright and licensing information, see the NOTICE and LICENSE
+// files in this project's top-level directory, and at:
+//   http://landis-extensions.googlecode.com/svn/libs/harvest-mgmt/trunk/
+
+using Landis.SpatialModeling;
+
+namespace Landis.Library.HarvestManagement
+{
+    /// <summary>
+    /// A ranking requirement which marks a stand for harvest if it has met the time since last wind
+    /// </summary>
+    public class TimeSinceLastWind
+        : IRequirement
+    {
+        private ushort timeSinceWind;
+
+        //---------------------------------------------------------------------
+
+        public TimeSinceLastWind(ushort windtime)
+        {
+            timeSinceWind = windtime;
+        }
+
+        //---------------------------------------------------------------------
+
+        bool IRequirement.MetBy(Stand stand)
+        {
+            double avgtime = 0;
+            int num = 0;
+
+            if (SiteVars.TimeOfLastWind != null)
+            {
+                foreach (ActiveSite site in stand)
+                {
+                    avgtime = avgtime + SiteVars.TimeOfLastWind[(Site)site];
+                    num = num + 1;
+                }
+            }
+
+            avgtime = avgtime / num;
+
+            if (num == 0)
+            {
+                return false;
+            }
+
+            return avgtime >= timeSinceWind;
+        }
+    }
+}


### PR DESCRIPTION
Added new stand-ranking method and two new requirements. The
stand-ranking method goes by time since last disturbance - wind, fire,
or both and if the average time since the last disturbance across a
stand's sites are greater than or equal to the time specified by the
user, then the stand is set aside for harvesting. This is an
implementation of salvage logging, issue #1 in base-harvest should be
resolved now.